### PR TITLE
Added debounce code to avoid unexpected shutdowns

### DIFF
--- a/softshut.py
+++ b/softshut.py
@@ -3,6 +3,7 @@
 # Import the modules to send commands to the system and access GPIO pins
 from subprocess import call
 import RPi.GPIO as GPIO
+from time import sleep
 
 # Map pin seven and eight on the Pi Switch PCB to chosen pins on the Raspberry Pi header
 # The PCB numbering is a legacy with the original design of the board
@@ -12,7 +13,9 @@ GPIO.setmode(GPIO.BOARD) # Set pin numbering to board numbering
 GPIO.setup(PinSeven, GPIO.IN) # Set up PinSeven as an input
 GPIO.setup(PinEight, GPIO.OUT, initial=1) # Setup PinEight as output
 
-GPIO.wait_for_edge(PinSeven, GPIO.RISING) # Wait for a rising edge on PinSeven
+while (GPIO.input(PinSeven) == False): # While button not pressed
+ GPIO.wait_for_edge(PinSeven, GPIO.RISING) # Wait for a rising edge on PinSeven
+ sleep(0.1); # Sleep 100ms to avoid triggering a shutdown when a spike occured
 
 GPIO.output(PinEight,0) # Bring down PinEight so that the capacitor can discharge an remove power to the Pi
 call('poweroff', shell=False) # Initiate OS Poweroff


### PR DESCRIPTION
Fixes issue #7 

When applying this PR, the button has to be pressed for at least 100ms to invoke a shutdown. 